### PR TITLE
caption and styling part of publication page

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -73,16 +73,19 @@ ul.publications {
   padding: 0;
 }
 
-li.publication {
+li.publication, div.publication {
   margin: 0 auto 3em auto;
   padding: 1.5em;
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+li.publication {
   border-bottom: 7px solid var(--accent-color);
 }
 
-li.publication figure {
+li.publication figure , div.publication figure{
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -90,19 +93,19 @@ li.publication figure {
   margin-bottom: 0;
 }
 
-li.publication figure img{
+li.publication figure img , div.publication figure img {
   max-width: 100%;
 }
 
-li.publication figcaption {
-  max-width: 60vw;
+li.publication figcaption , div.publication figcaption {
+  max-width: 50vw;
   margin: 1em auto 1em auto;
   font-size: 0.75em;
   font-family: var(--secondary_text);
   font-style: italic;
 }
  
-li.publication div.description {
+li.publication div.description , div.publication div.description {
   max-width: 80%;
   margin: 1em auto auto auto;
 }
@@ -145,7 +148,7 @@ nav.pagination button {
 }
 
 @media (max-width: 667px) {
-  li.publication , figure {
+  li.publication , div.publication ,  figure {
     padding: 0.25em;
     margin-left: 0;
     margin-right: 0;

--- a/pages/publication.js
+++ b/pages/publication.js
@@ -26,6 +26,7 @@ ${nav({ me: state.ssb.id })}
     timestamp: msg.timestamp,
     title: msg.content.title,
     description: msg.content.description,
+    caption: msg.content.caption,
     size: msg.content.size,
     msgId,
     author,


### PR DESCRIPTION
This is an append to #5 .  It looks like the publication page wasn't passing along captions, and I was too strict with the `.publication` styling, to only apply to `<li>` elements tagged with that class.  It applies to `div.publication` now as well 