### PR TITLE
Updated Publishing Form

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -73,7 +73,9 @@ ul.publications {
   padding: 0;
 }
 
-li.publication, div.publication {
+li.publication ,
+div.publication ,
+#publish-form {
   margin: 0 auto 3em auto;
   padding: 1.5em;
   display: flex;
@@ -85,7 +87,8 @@ li.publication {
   border-bottom: 7px solid var(--accent-color);
 }
 
-li.publication figure , div.publication figure{
+li.publication figure ,
+div.publication figure {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -93,31 +96,65 @@ li.publication figure , div.publication figure{
   margin-bottom: 0;
 }
 
-li.publication figure img , div.publication figure img {
+li.publication figure img ,
+div.publication figure img {
   max-width: 100%;
 }
 
-li.publication figcaption , div.publication figcaption {
+li.publication figcaption ,
+div.publication figcaption {
   max-width: 50vw;
   margin: 1em auto 1em auto;
   font-size: 0.75em;
   font-family: var(--secondary_text);
   font-style: italic;
 }
- 
-li.publication div.description , div.publication div.description {
+
+li.publication div.description ,
+div.publication div.description {
   max-width: 80%;
   margin: 1em auto auto auto;
 }
+#publish-form span.description {
+  max-width: 80%;
+}
 
-div.description div.publicationDescription {
+#publish-form textarea#imgDesc {
+  background: none;
+  border: none;
+  width: 70vw;
+  min-height: 150px;
+  font-size: 20px;
+}
+
+#publish-form textarea#imgDesc::placeholder {
+  font-size: 20px;
+}
+
+
+
+div.description ,
+div.publicationDescription ,
+#publish-form textarea#imgDesc {
   margin: 1em auto 1.5em auto;
 }
 
-h2.publicationTitle {
+h2.publicationTitle ,
+form#publish-form input#imgTitle {
   font-size: 1.3em;
   font-weight: 700;
   margin-bottom: 0;
+}
+
+form#publish-form input#imgTitle {
+  background: none;
+  border: none;
+  width: 70vw;
+}
+
+form#publish-form ::placeholder {
+  opacity: 1;
+  color: var(--primary_color);
 }
 
 a.author {
@@ -161,21 +198,36 @@ nav.pagination button {
   }
 }
 
-
-form {
-  padding: 1.5em;
-}
-
-#imgInput, #imgTitle, #imgDesc, #imgCaption {
-  display: block;
+#publish-form label[for="imgInput"] {
+  font-size: 2em;
   margin-bottom: 1em;
 }
 
-#imgDesc, #imgCaption {
-  width: 40em;
-  height: 25em;
+#publish-form label:not([for='imgInput']) {
+  display: none;
 }
 
-#imgTitle {
-  width: 40em;
+#publish-form input[type='file'] {
+  margin-bottom: 2em;
+}
+
+#publish-form #imgCaption {
+  width: 50vw;
+  height: 150px;
+  border: none;
+  background: transparent;
+  margin: 1em auto 2em auto;
+  font-family: var(--secondary_text);
+  font-style: italic;
+}
+
+#publish-form #imgCaption::placeholder, #imgCaption {
+  font-size: 18px;
+}
+
+#publish-form input[type='submit'] {
+  margin-top: 0;
+  width: 50vw;
+  height: 40px;
+  background: var(--accent-color);
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -280,6 +280,7 @@ textarea#imgDesc:focus {
   justify-content: center;
   align-items: center;
   width: 80%;
+  margin: auto;
 }
 
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -75,6 +75,7 @@ ul.publications {
 
 li.publication ,
 div.publication ,
+div.preview ,
 #publish-form {
   margin: 0 auto 3em auto;
   padding: 1.5em;
@@ -88,7 +89,9 @@ li.publication {
 }
 
 li.publication figure ,
-div.publication figure {
+div.preview figure ,
+div.publication figure ,
+span.publish-figure {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -97,11 +100,14 @@ div.publication figure {
 }
 
 li.publication figure img ,
-div.publication figure img {
+div.preview figure img ,
+div.publication figure img ,
+span.publish-figure img {
   max-width: 100%;
 }
 
 li.publication figcaption ,
+div.preview figcaption ,
 div.publication figcaption {
   max-width: 50vw;
   margin: 1em auto 1em auto;
@@ -111,6 +117,7 @@ div.publication figcaption {
 }
 
 li.publication div.description ,
+div.preview div.description ,
 div.publication div.description {
   max-width: 80%;
   margin: 1em auto auto auto;
@@ -130,8 +137,6 @@ div.publication div.description {
 #publish-form textarea#imgDesc::placeholder {
   font-size: 20px;
 }
-
-
 
 div.description ,
 div.publicationDescription ,
@@ -198,17 +203,28 @@ nav.pagination button {
   }
 }
 
-#publish-form label[for="imgInput"] {
+#img-input-form {
+  height: 80vh;
+  width: 80%;
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+#img-input-form label[for="imgInput"],
+div.publish-form-addl-details h1 {
   font-size: 2em;
   margin-bottom: 1em;
 }
 
-#publish-form label:not([for='imgInput']) {
-  display: none;
+div.publish-form-addl-details h1 {
+  text-align: center;
 }
 
-#publish-form input[type='file'] {
-  margin-bottom: 2em;
+#publish-form label {
+  display: none;
 }
 
 #publish-form #imgCaption {
@@ -221,7 +237,8 @@ nav.pagination button {
   font-style: italic;
 }
 
-#publish-form #imgCaption::placeholder, #imgCaption {
+#publish-form #imgCaption::placeholder ,
+#imgCaption {
   font-size: 18px;
 }
 
@@ -231,3 +248,38 @@ nav.pagination button {
   height: 40px;
   background: var(--accent-color);
 }
+
+#publish-form button#removeImg ,
+#publish-preview button {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  height: 40px;
+  background: var(--accent-color);
+}
+
+#publish-preview button {
+  margin-bottom: 0.5em;
+  font-size: 24px;
+  background: var(--accent-color);
+}
+
+textarea#imgCaption:focus,
+input#imgTitle:focus,
+textarea#imgDesc:focus {
+  background: var(--accent-color) !important;
+  opacity: 0.5;
+}
+
+#publish-form input[name="imgInput"]{
+  display: none !important;
+}
+
+#publish-preview {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 80%;
+}
+
+

--- a/pages/preview.js
+++ b/pages/preview.js
@@ -21,8 +21,10 @@ module.exports = (state, emit) => {
       authorId: preview.ssb.id,
       blob: preview.imgFile,
     }, emit)}</div>
-  <button class="previewCancel" onclick="${oncancel}">Cancel</button>
-  <button class="previewConfirm" onclick="${onconfirm}">Confirm</button>
+  <div id='publish-preview'>
+    <button class="previewConfirm" onclick="${onconfirm}">Confirm</button>
+    <button class="previewCancel" onclick="${oncancel}">Cancel</button>
+  </div>
 </body>`;
 
   function oncancel() {

--- a/pages/publish.js
+++ b/pages/publish.js
@@ -32,11 +32,13 @@ module.exports = (state, emit) => {
       `
     }
     <label for="imgCaption">Caption</label>
-    <textarea name="imgCaption" id="imgCaption">${state.publishData.caption}</textarea>
+      <textarea name="imgCaption" id="imgCaption" placeholder="HEY HEY WRITE A CAPTION!  Please describe, as accurately and concisely as possible, the visual details of your image. This wouldn't be additional context or stories about the image, but a literal description of it.  This helps accessibility for visually impaired friends."></textarea>
     <label for="imgTitle">Title</label>
-    <input type="text" name="imgTitle" id="imgTitle" value="${state.publishData.title}">
+      <input type="text" name="imgTitle" id="imgTitle" value="" placeholder="HEY HEY WRITE A TITLE!">
     <label for="imgDesc">Description</label>
-    <textarea name="imgDesc" id="imgDesc">${state.publishData.description}</textarea>
+    <span class='description'>
+      <textarea name="imgDesc" id="imgDesc" placeholder="AND HEY HEY, WRITE A DESCRIPTION!  Here is the best place for any feelings, contexts, stories, and what-have-you about the image you've shared.  It's optional of course.  Everything is."></textarea>
+    </span>
     <input type="submit" name="publish" value="Preview & Publish">
   </form>
 </body>`;

--- a/pages/publish.js
+++ b/pages/publish.js
@@ -1,36 +1,57 @@
-const html = require('choo/html');
-const pull = require('pull-stream');
-const once = require('pull-stream/sources/once');
-const pullFileReader = require('pull-filereader');
+const html = require('choo/html')
+const pull = require('pull-stream')
+const once = require('pull-stream/sources/once')
+const pullFileReader = require('pull-filereader')
 
-const nav = require('../views/nav');
+const nav = require('../views/nav')
 
 module.exports = (state, emit) => {
   return html`<body>
   ${nav({ me: state.ssb.id })}
   ${
-    state.publishError ?
-    html`<div class="error">
-      ${
-        state.publishError.message === 'encoded message must not be larger than 8192 bytes' ?
-        html`The description, caption or title is too large, you'll need to cut some words.` :
-        html`An unexpected error occured.<code>${JSON.stringify(state.publishError)}</code>`
+  state.publishError
+    ? html`<div class="error">
+     ${
+    state.publishError.message === 'encoded message must not be larger than 8192 bytes' ?
+    html`The description, caption or title is too large, you'll need to cut some words.` :
+    html`An unexpected error occured.<code>${JSON.stringify(state.publishError)}</code>`
       }
-    </div>` :
-    html``
+    </div>`
+    : html``
   }
-  <form onsubmit="${onsubmit}">
-    <label for="imgInput">Select an image to publish</label>
-    <input type="file" name="imgInput" id="imgInput" accept="image/gif, image/jpeg, image/png, , image/apng" required>
+  <form onsubmit="${onsubmit}" id='publish-form'>
+    ${state.publishInput.blob
+      ? html`
+        <div>
+          <button onclick=${removeImage}>Remove Image</button>
+          <img class="publicationImg" src="${URL.createObjectURL(state.publishInput.blob)}" />
+        </div>`
+      : html`
+        <label for="imgInput">Select an image to publish</label>
+        <input type="file" onchange=${onChange} name="imgInput" id="imgInput" accept="image/gif, image/jpeg, image/png, , image/apng" required>
+      `
+    }
+    <label for="imgCaption">Caption</label>
+    <textarea name="imgCaption" id="imgCaption">${state.publishData.caption}</textarea>
     <label for="imgTitle">Title</label>
     <input type="text" name="imgTitle" id="imgTitle" value="${state.publishData.title}">
     <label for="imgDesc">Description</label>
     <textarea name="imgDesc" id="imgDesc">${state.publishData.description}</textarea>
-    <label for="imgCaption">Caption</label>
-    <textarea name="imgCaption" id="imgCaption">${state.publishData.caption}</textarea>
     <input type="submit" name="publish" value="Preview & Publish">
   </form>
 </body>`;
+
+  function onChange (event) {
+    event.preventDefault();
+    const imgInput = document.querySelector('#imgInput');
+    const imgFile = imgInput.files[0];
+    emit('preview image added', imgFile)
+  }
+
+  function removeImage () {
+    event.preventDefault()
+    emit('preview image removed')
+  }
 
   function onsubmit(event) {
     event.preventDefault();

--- a/pages/publish.js
+++ b/pages/publish.js
@@ -19,28 +19,43 @@ module.exports = (state, emit) => {
     </div>`
     : html``
   }
-  <form onsubmit="${onsubmit}" id='publish-form'>
-    ${state.publishInput.blob
-      ? html`
-        <div>
-          <button onclick=${removeImage}>Remove Image</button>
-          <img class="publicationImg" src="${URL.createObjectURL(state.publishInput.blob)}" />
-        </div>`
-      : html`
-        <label for="imgInput">Select an image to publish</label>
-        <input type="file" onchange=${onChange} name="imgInput" id="imgInput" accept="image/gif, image/jpeg, image/png, , image/apng" required>
+  ${state.publishInput.blob
+  // When an image file has been selected, display the add'l details form
+    ? html`
+      <div class='publish-form-addl-details'>
+      <h1>Add Additional Details</h1>
+      <form onsubmit="${onsubmit}" id='publish-form'>
+          <span class='publish-figure'>
+            <img class="publicationImg" src="${URL.createObjectURL(state.publishInput.blob)}" />
+            <button id="removeImg" onclick=${removeImage}>Remove Image</button>
+            <input class='hidden' disabled type="file" name="imgInput" id="imgInput" accept="image/gif, image/jpeg, image/png, image/apng" >
+            <label for="imgCaption">Caption</label>
+            <textarea name="imgCaption" id="imgCaption" placeholder="HEY HEY, CLICK TO WRITE A CAPTION HERE!  Please describe, as accurately and concisely as possible, the visual details of your image. This wouldn't be additional context or stories about the image, but a literal description of it.  This helps accessibility for visually impaired friends."></textarea>
+          </span>
+          <label for="imgTitle">Title</label>
+          <input type="text" name="imgTitle" id="imgTitle" value="" placeholder="HEY HEY WRITE A TITLE HERE!">
+          <label for="imgDesc">Description</label>
+          <span class='description'>
+            <textarea name="imgDesc" id="imgDesc" placeholder="AND HEY HEY, WRITE A DESCRIPTION HERE!  Here is the best place for any feelings, contexts, stories, and what-have-you about the image you've shared.  It's optional of course.  Everything is."></textarea>
+          </span>
+          <input type="submit" name="publish" value="Preview & Publish">
+        </form>
+        </div>
+        `
+  // Otherwise, display the image file selector
+    : html`
+        <form id='img-input-form'>
+          <label for="imgInput">Select an image to publish</label>
+        <input
+          type="file"
+          onchange=${onChange}
+          name="imgInput"
+          id="imgInput"
+          accept="image/gif, image/jpeg, image/png, , image/apng"
+          required>
+        </form>
       `
     }
-    <label for="imgCaption">Caption</label>
-      <textarea name="imgCaption" id="imgCaption" placeholder="HEY HEY WRITE A CAPTION!  Please describe, as accurately and concisely as possible, the visual details of your image. This wouldn't be additional context or stories about the image, but a literal description of it.  This helps accessibility for visually impaired friends."></textarea>
-    <label for="imgTitle">Title</label>
-      <input type="text" name="imgTitle" id="imgTitle" value="" placeholder="HEY HEY WRITE A TITLE!">
-    <label for="imgDesc">Description</label>
-    <span class='description'>
-      <textarea name="imgDesc" id="imgDesc" placeholder="AND HEY HEY, WRITE A DESCRIPTION!  Here is the best place for any feelings, contexts, stories, and what-have-you about the image you've shared.  It's optional of course.  Everything is."></textarea>
-    </span>
-    <input type="submit" name="publish" value="Preview & Publish">
-  </form>
 </body>`;
 
   function onChange (event) {
@@ -59,7 +74,7 @@ module.exports = (state, emit) => {
     event.preventDefault();
 
     const imgInput = document.querySelector('#imgInput');
-    const imgFile = imgInput.files[0];
+    var imgFile = imgInput.files[0];
 
     const imgTitle = document.querySelector('#imgTitle');
     const title = imgTitle.value;
@@ -69,6 +84,10 @@ module.exports = (state, emit) => {
 
     const imgCaption = document.querySelector('#imgCaption');
     const caption = imgCaption.value;
+
+    if (!imgFile) {
+      imgFile = state.publishInput.blob
+    }
 
     emit('preview', {
       imgFile,

--- a/stores/publish.js
+++ b/stores/publish.js
@@ -12,7 +12,6 @@ module.exports = (state, emitter, app) => {
 
     emitter.on('preview image added', data => {
         state.publishInput.blob = data;
-        console.log({imgState: state.publishInput})
         emitter.emit('pushState', '/publish')
     });
 
@@ -22,6 +21,7 @@ module.exports = (state, emitter, app) => {
     });
 
     emitter.on('publishData', data => {
+      state.publishInput= {};
       state.publishData = data;
     });
 

--- a/stores/publish.js
+++ b/stores/publish.js
@@ -2,11 +2,23 @@ const client = require('ssb-client');
 
 module.exports = (state, emitter, app) => {
   state.publishData = {};
+  state.publishInput = {};
 
   emitter.on('DOMContentLoaded', () => {
     emitter.on('preview', data => {
       state.preview = data;
       emitter.emit('pushState', '/preview')
+    });
+
+    emitter.on('preview image added', data => {
+        state.publishInput.blob = data;
+        console.log({imgState: state.publishInput})
+        emitter.emit('pushState', '/publish')
+    });
+
+    emitter.on('preview image removed', data => {
+      state.publishInput.blob = null
+      emitter.emit('pushState', '/publish')
     });
 
     emitter.on('publishData', data => {


### PR DESCRIPTION
This is a bit of an overhaul for publishing, to make it easier to tell which input field relates to which part of your post (and to make the whole thing aesthetically pleasing).

In this new style, when you click publish, you just see an option to browse files to add an image.  When you add it, the image appears, along with the caption, title, and description fields as they'd be styled on the main page.  You can then work through them all making it look good before hitting 'preview and publish'.

To do this, I added some add'l 'onChange' logic to the form and an additional state to `stores/publish.js` to hold that temporary image.  You might want to check the logic to see if it's sound!